### PR TITLE
Fix get_transaction_info path_prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v0.2.1
 
-- Remove unecessary slash from transaction_info call.
+- Remove unecessary slash from get_transaction_info call.
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+## v0.2.1
+
+- Remove unecessary slash from transaction_info call.
+
 ## v0.2.0
 
 - Remove `nanoid` dependency.

--- a/lib/app_store.ex
+++ b/lib/app_store.ex
@@ -5,7 +5,7 @@ defmodule AppStore do
 
   alias AppStore.{API, Token}
 
-  @version "0.2.0"
+  @version "0.2.1"
 
   @enforce_keys [:api_config, :token_config]
 

--- a/lib/app_store/api/transaction_info.ex
+++ b/lib/app_store/api/transaction_info.ex
@@ -7,7 +7,7 @@ defmodule AppStore.API.TransactionInfo do
 
   @type transaction_id :: String.t()
 
-  @path_prefix "/inApps/v1/transactions/"
+  @path_prefix "/inApps/v1/transactions"
 
   @doc """
   Get information about a single transaction for your app.


### PR DESCRIPTION
This commit fixes the 'get_transaction_info' call by removing the unnecessary slash at the end of the `@path_prefix` module variable.

If it needs additional info or tests let me know.