### PR TITLE
Add support for test notification endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+## v0.3.x
+
+- Added Test Notification endpoint support: `AppStore.API.TestNotification`.
+
 ## v0.3.1
 
 - Move Public Apple Certificate to jws_validation directory.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ iex> app_store = AppStore.build()
 Generate a token:
 
 ```elixir
-iex> token = AppStore.Token.generate_token(
+iex> {:ok, token, payload_map} = AppStore.Token.generate_token(
   "57246542-96fe-1a63-e053-0824d011072a",
   "com.example.testbundleid2021",
   %{

--- a/lib/app_store/api/api.ex
+++ b/lib/app_store/api/api.ex
@@ -30,4 +30,7 @@ defmodule AppStore.API do
 
   defdelegate send_test_notification(api_config, body),
     to: TestNotification
+
+  defdelegate get_test_notification_status(api_config, token, test_notification_token),
+    to: TestNotification
 end

--- a/lib/app_store/api/api.ex
+++ b/lib/app_store/api/api.ex
@@ -7,7 +7,8 @@ defmodule AppStore.API do
     TransactionHistory,
     TransactionInfo,
     SubscriptionStatus,
-    ConsumptionInformation
+    ConsumptionInformation,
+    TestNotification
   }
 
   defdelegate get_transaction_history(
@@ -26,4 +27,7 @@ defmodule AppStore.API do
 
   defdelegate send_consumption_information(api_config, token, original_transaction_id, body),
     to: ConsumptionInformation
+
+  defdelegate send_test_notification(api_config, body),
+    to: TestNotification
 end

--- a/lib/app_store/api/http.ex
+++ b/lib/app_store/api/http.ex
@@ -12,6 +12,10 @@ defmodule AppStore.API.HTTP do
     perform_request(api_config, token, :put, path, body)
   end
 
+  def post(%Config{} = api_config, token, path, body \\ nil) do
+    perform_request(api_config, token, :post, path, body)
+  end
+
   defp perform_request(
          %Config{http_client: http_client, json_coder: json_coder, server_url: server_url},
          token,

--- a/lib/app_store/api/test_notification.ex
+++ b/lib/app_store/api/test_notification.ex
@@ -1,0 +1,20 @@
+defmodule AppStore.API.TestNotification do
+  @moduledoc """
+  The module for Test Notification
+  """
+
+  alias AppStore.API.{Config, Error, Response, HTTP}
+
+  @path "/inApps/v1/notifications/test"
+
+  @doc """
+  Send a test notification to the App Store.
+
+  Official documentation: https://developer.apple.com/documentation/appstoreserverapi/request-a-test-notification
+  """
+  @spec send_test_notification(Config.t(), String.t()) ::
+          {:error, Error.t()} | {:ok, Response.t()}
+  def send_test_notification(%Config{} = api_config, token)  do
+    HTTP.post(api_config, token, @path)
+  end
+end

--- a/lib/app_store/api/test_notification.ex
+++ b/lib/app_store/api/test_notification.ex
@@ -20,6 +20,7 @@ defmodule AppStore.API.TestNotification do
 
   @doc """
   Get the status of a test notification.
+
   Official documentation: https://developer.apple.com/documentation/appstoreserverapi/get-test-notification-status
   """
   @spec get_test_notification_status(Config.t(), String.t(), String.t()) ::

--- a/lib/app_store/api/test_notification.ex
+++ b/lib/app_store/api/test_notification.ex
@@ -5,7 +5,7 @@ defmodule AppStore.API.TestNotification do
 
   alias AppStore.API.{Config, Error, Response, HTTP}
 
-  @path "/inApps/v1/notifications/test"
+  @path_prefix "/inApps/v1/notifications/test"
 
   @doc """
   Send a test notification to the App Store.
@@ -15,6 +15,16 @@ defmodule AppStore.API.TestNotification do
   @spec send_test_notification(Config.t(), String.t()) ::
           {:error, Error.t()} | {:ok, Response.t()}
   def send_test_notification(%Config{} = api_config, token)  do
-    HTTP.post(api_config, token, @path)
+    HTTP.post(api_config, token, @path_prefix)
+  end
+
+  @doc """
+  Get the status of a test notification.
+  Official documentation: https://developer.apple.com/documentation/appstoreserverapi/get-test-notification-status
+  """
+  @spec get_test_notification_status(Config.t(), String.t(), String.t()) ::
+          {:error, Error.t()} | {:ok, Response.t()}
+  def get_test_notification_status(%Config{} = api_config, token, test_notification_token) do
+    HTTP.get(api_config, token, "#{@path_prefix}/#{test_notification_token}")
   end
 end

--- a/lib/app_store/http_client/http_client.ex
+++ b/lib/app_store/http_client/http_client.ex
@@ -46,7 +46,7 @@ defmodule AppStore.HTTPClient do
   See `AppStore.HTTPClient.DefaultClient` for a reference implementation.
   """
 
-  @type http_method :: :get | :put
+  @type http_method :: :get | :put | :post
   @type http_headers :: [{header_name :: String.t(), header_value :: String.t()}]
   @type http_response :: %{
           data: map(),

--- a/test/app_store/api/test_notification_test.exs
+++ b/test/app_store/api/test_notification_test.exs
@@ -26,7 +26,7 @@ defmodule AppStore.API.TestNotificationTest do
 
   describe "get_test_notification_status/3" do
     test "gets the status of a test notification", %{bypass: bypass, app_store: app_store} do
-      expected_body = ""
+      expected_body = %{signedPayload: "signed_payload_value"} |> Jason.encode!()
 
       Bypass.expect_once(bypass, "GET", "/inApps/v1/notifications/test/notification_id", fn conn ->
         conn

--- a/test/app_store/api/test_notification_test.exs
+++ b/test/app_store/api/test_notification_test.exs
@@ -23,4 +23,26 @@ defmodule AppStore.API.TestNotificationTest do
       assert body === expected_body
     end
   end
+
+  describe "get_test_notification_status/3" do
+    test "gets the status of a test notification", %{bypass: bypass, app_store: app_store} do
+      expected_body = ""
+
+      Bypass.expect_once(bypass, "GET", "/inApps/v1/notifications/test/notification_id", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("server", "daiquiri/3.0.0")
+        |> Plug.Conn.resp(200, expected_body)
+      end)
+
+      {:ok, %AppStore.API.Response{body: body, status: status}} =
+        TestNotification.get_test_notification_status(
+          app_store.api_config,
+          "token",
+          "notification_id"
+        )
+
+      assert status === 200
+      assert body === expected_body
+    end
+  end
 end

--- a/test/app_store/api/test_notification_test.exs
+++ b/test/app_store/api/test_notification_test.exs
@@ -1,0 +1,26 @@
+defmodule AppStore.API.TestNotificationTest do
+  use AppStore.TestCase, async: false
+
+  alias AppStore.API.TestNotification
+
+  describe "send_test_notification/2" do
+    test "sends a test notification", %{bypass: bypass, app_store: app_store} do
+      expected_body = %{signedPayload: "signed_payload_value"} |> Jason.encode!()
+
+      Bypass.expect_once(bypass, "POST", "/inApps/v1/notifications/test", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("server", "daiquiri/3.0.0")
+        |> Plug.Conn.resp(200, expected_body)
+      end)
+
+      {:ok, %AppStore.API.Response{body: body, status: status}} =
+        TestNotification.send_test_notification(
+          app_store.api_config,
+          "token"
+        )
+
+      assert status === 200
+      assert body === expected_body
+    end
+  end
+end


### PR DESCRIPTION
Hi there,

Thanks for making this library!

I found it really useful for adding support for App Store server-side API integration.

The `JWSValidation` helpers are also really useful for implementing push notifications.

While testing push notifications end-to-end, I found it helpful to add support for the test notification endpoints to the client library.

Hope this is helpful for others as well.

I also noticed a small typo in the README, re: the response payload of `generate_token` which returns a tuple, so went ahead and fixed that example while I was at it.